### PR TITLE
refactor: remove unnecessary check after ReadAt

### DIFF
--- a/internal/store/wal/stream.go
+++ b/internal/store/wal/stream.go
@@ -106,13 +106,8 @@ func (s *logStream) Visit(visitor WalkFunc, compacted int64) (int64, error) {
 		}
 
 		for at := firstBlockOffset(f.so, compacted); at < f.size; {
-			n, err := f.f.ReadAt(buf, at)
-			if err != nil {
+			if _, err := f.f.ReadAt(buf, at); err != nil {
 				return -1, err
-			}
-			if n != blockSize {
-				// TODO(james.yin): incomplete block
-				panic("WAL: incomplete block")
 			}
 
 			for so := 0; so <= blockSize-record.HeaderSize; {
@@ -183,7 +178,7 @@ func (s *logStream) Visit(visitor WalkFunc, compacted int64) (int64, error) {
 				}
 			}
 
-			at += int64(n)
+			at += blockSize
 		}
 
 		// TODO(james.yin): close log file

--- a/internal/store/wal/wal.go
+++ b/internal/store/wal/wal.go
@@ -104,12 +104,8 @@ func newWAL(ctx context.Context, stream *logStream, pos int64) (*WAL, error) {
 	// recover write block
 	if pos > 0 {
 		f := stream.selectFile(w.wb.so)
-		n, err := f.f.ReadAt(w.wb.buf, w.wb.so-f.so)
-		if err != nil {
+		if _, err := f.f.ReadAt(w.wb.buf, w.wb.so-f.so); err != nil {
 			return nil, err
-		}
-		// TODO(james.yin): incomplete block
-		if n != blockSize {
 		}
 		w.wb.wp = int(pos - w.wb.so)
 		w.wb.fp = w.wb.wp


### PR DESCRIPTION
ReadAt() always returns a non-nil error when n < len(b).