### PR TITLE
ci: add timeout arg to golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -31,7 +31,7 @@ jobs:
           working-directory: internal
 
           # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
+          args: --timeout 3m
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: false


### PR DESCRIPTION
add timeout arg to `golangci-lint` because of the lint occasionally failed