### PR TITLE
chore: add PR and issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,19 @@
+---
+name: "\U0001F41B Bug Report"
+about: As a User, I want to report a Bug.
+labels: type/bug
+---
+
+## Bug Report
+
+Please answer these questions before submitting your issue. Thanks!
+
+### 1. Minimal reproduce step (Required)
+
+<!-- a step by step guide for reproducing the bug. -->
+
+### 2. What did you expect to see? (Required)
+
+### 3. What did you see instead (Required)
+
+### 4. What is your Vanus version? (Required)

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,7 @@
+---
+name: "\U0001F680 Enhancement"
+about: As a Vanus developer, I want to make an enhancement.
+labels: type/enhancement
+---
+
+## Enhancement

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,19 @@
+---
+name: "\U0001F680 Feature Request"
+about: As a user, I want to request a New Feature on the product.
+labels: type/feature-request
+---
+
+## Feature Request
+
+**Is your feature request related to a problem? Please describe:**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the feature you'd like:**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered:**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Teachability, Documentation, Adoption, Migration Strategy:**
+<!-- If you can, explain some scenarios how users might use this, situations it would be helpful in. Any API designs, mockups, or diagrams are also helpful. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,20 @@
+---
+name: "\U0001F914 Ask a Question"
+about: I want to ask a question.
+labels: type/question
+---
+
+## Question
+
+<!--
+
+Before asking a question, make sure you have:
+
+- Searched existing Stack Overflow questions.
+- Googled your question.
+- Searched open and closed [GitHub issues](https://github.com/linkall-labs/vanus/issues)
+- Read the documentation:
+  - [Vanus Readme](https://github.com/linkall-labs/vanus)
+  - [Vanus Docs](https://github.com/linkall-labs/docs)
+
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+<!--
+
+Thank you for contributing to Vanus!
+
+PR Title Format: 
+
+feat/fix/refactor/docs/...: what's changed
+
+Note: see https://github.com/linkall-labs/vanus/blob/main/CONTRIBUTING.md to know details about title format
+-->
+
+### What problem does this PR solve?
+<!--
+
+Please create an issue first to describe the problem
+
+There MUST be one line starting with "Issue Number:  ".
+
+-->
+
+Issue Number: close #xxx
+
+Problem Summary:
+
+### What is changed and how it works?
+
+### Check List
+
+<!-- At least one of them must be included. -->
+
+#### Tests
+- [ ] Unit test
+- [ ] Integration test
+- [ ] Manual test (add detailed scripts or steps below)
+- [ ] No code
+


### PR DESCRIPTION
add templates for PR and issues. All templates in this PR are referred to TiDB: https://github.com/pingcap/tidb/tree/master/.github