### PR TITLE
build: cancel liveness probe

### DIFF
--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -179,12 +179,6 @@ spec:
               fieldPath: status.podIP
         image: public.ecr.aws/vanus/trigger:v0.1.1
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 10
-          grpc:
-            port: 2148
-          initialDelaySeconds: 30
-          periodSeconds: 30
         name: trigger
         ports:
         - containerPort: 2148
@@ -229,11 +223,6 @@ spec:
               fieldPath: status.podIP
         image: public.ecr.aws/vanus/controller:v0.1.1
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 10
-          grpc:
-            port: 2048
-          periodSeconds: 30
         name: controller
         ports:
         - containerPort: 2048
@@ -295,12 +284,6 @@ spec:
               fieldPath: status.podIP
         image: public.ecr.aws/vanus/store:v0.1.1
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 10
-          grpc:
-            port: 11811
-          initialDelaySeconds: 30
-          periodSeconds: 30
         name: store
         ports:
         - containerPort: 11811

--- a/deploy/yaml/controller.yaml
+++ b/deploy/yaml/controller.yaml
@@ -89,11 +89,11 @@ spec:
         - name: controller
           image: public.ecr.aws/vanus/controller:v0.1.1
           imagePullPolicy: IfNotPresent
-          livenessProbe:
-            grpc:
-              port: 2048
-            failureThreshold: 10
-            periodSeconds: 30
+#          livenessProbe:
+#            grpc:
+#              port: 2048
+#            failureThreshold: 10
+#            periodSeconds: 30
           ports:
             - name: grpc
               containerPort: 2048

--- a/deploy/yaml/store.yaml
+++ b/deploy/yaml/store.yaml
@@ -64,12 +64,12 @@ spec:
           image: public.ecr.aws/vanus/store:v0.1.1
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "-c", "VOLUME_ID=${HOSTNAME##*-} /vanus/bin/store"]
-          livenessProbe:
-            grpc:
-              port: 11811
-            failureThreshold: 10
-            periodSeconds: 30
-            initialDelaySeconds: 30
+#          livenessProbe:
+#            grpc:
+#              port: 11811
+#            failureThreshold: 10
+#            periodSeconds: 30
+#            initialDelaySeconds: 30
           ports:
             - name: grpc
               containerPort: 11811

--- a/deploy/yaml/trigger.yaml
+++ b/deploy/yaml/trigger.yaml
@@ -47,12 +47,12 @@ spec:
         - name: trigger
           image: public.ecr.aws/vanus/trigger:v0.1.1
           imagePullPolicy: IfNotPresent
-          livenessProbe:
-            grpc:
-              port: 2148
-            failureThreshold: 10
-            periodSeconds: 30
-            initialDelaySeconds: 30
+#          livenessProbe:
+#            grpc:
+#              port: 2148
+#            failureThreshold: 10
+#            periodSeconds: 30
+#            initialDelaySeconds: 30
           ports:
             - name: grpc
               containerPort: 2148


### PR DESCRIPTION
<!--

Thank you for contributing to Vanus!

PR Title Format: 

feat/fix/refactor/docs/...: what's changed

Note: see https://github.com/linkall-labs/vanus/blob/main/CONTRIBUTING.md to know details about title format
-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem

There MUST be one line starting with "Issue Number:  ".

-->

Issue Number: close #xxx

### Problem Summary:
It seems the `liveness` probe doesn't work well, which causes the pods restart again and again, so cancel it. The probe should be added back until testing well
### What is changed and how it works?

### Check List

<!-- At least one of them must be included. -->

#### Tests
- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

