### PR TITLE
feat: return events with log offset

### DIFF
--- a/client/internal/vanus/eventlog/log_segment.go
+++ b/client/internal/vanus/eventlog/log_segment.go
@@ -17,6 +17,7 @@ package eventlog
 import (
 	// standard libraries
 	"context"
+	"encoding/binary"
 	"math"
 	"sync"
 
@@ -168,6 +169,15 @@ func (s *logSegment) Read(ctx context.Context, from int64, size int16) ([]*ce.Ev
 	if err != nil {
 		return nil, err
 	}
+
+	for _, e := range events {
+		eventBlockOff, _ := e.Extensions()["xvanusblockoff"].(int32)
+		offset := s.startOffset + int64(eventBlockOff)
+		buf := make([]byte, 8)
+		binary.BigEndian.PutUint64(buf, uint64(offset))
+		e.SetExtension("xvanuslogoff", buf)
+	}
+
 	return events, err
 }
 

--- a/internal/store/block/file/read.go
+++ b/internal/store/block/file/read.go
@@ -43,14 +43,16 @@ func (b *Block) Read(ctx context.Context, start, number int) ([]block.Entry, err
 	}
 
 	entries := make([]block.Entry, 0, num)
-	for so, from2 := uint32(0), uint32(from); so < length; {
+	for i, so, from2 := uint32(start), uint32(0), uint32(from); so < length; {
 		entry, err2 := block.UnmarshalEntry(data[so:])
 		if err2 != nil {
 			return nil, err2
 		}
 		entry.Offset = from2 + so
+		entry.Index = i
 		entries = append(entries, entry)
 		so += uint32(entry.Size())
+		i++
 	}
 
 	return entries, nil

--- a/internal/store/segment/server.go
+++ b/internal/store/segment/server.go
@@ -698,6 +698,11 @@ func (s *server) ReadFromBlock(ctx context.Context, id vanus.ID, off int, num in
 			return nil, errors.ErrInternal.WithMessage(
 				"unmarshall data to event failed").Wrap(err2)
 		}
+		event.Attributes["xvanusblockoff"] = &cepb.CloudEventAttributeValue{
+			Attr: &cepb.CloudEventAttributeValue_CeInteger{
+				CeInteger: int32(entry.Index),
+			},
+		}
 		events[i] = event
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to Vanus!

PR Title Format: 

feat/fix/refactor/docs/...: what's changed

Note: see https://github.com/linkall-labs/vanus/blob/main/CONTRIBUTING.md to know details about title format
-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem

There MUST be one line starting with "Issue Number:  ".

-->

Issue Number: None
This PR adds offset information in cloud event.

### Problem Summary
The client needs to use the offset information in event.

### What is changed and how does it work?
1.  Add the "xvanusblockoffset" attribute of event when the segment server responds to the client's reading block request.
2. In log_ segment.go, take out the "xvanusblockoff" attribute in events responded by the server then add the offset of segment. Finally, convert it into large byte order and set it to the new attribute "xvanuslogoffset" of event.

### Check List

<!-- At least one of them must be included. -->

#### Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
