### PR TITLE
feat: add backoff in transport

### DIFF
--- a/internal/raft/transport/backoff_timer.go
+++ b/internal/raft/transport/backoff_timer.go
@@ -1,0 +1,76 @@
+// Copyright 2022 Linkall Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"context"
+	"time"
+
+	"github.com/linkall-labs/vanus/observability/log"
+)
+
+type BackoffTimer struct {
+	startInterval  int64
+	curInterval    int64
+	maxInterval    int64
+	expire         int64
+	useCanTryFirst bool
+}
+
+func NewBackoffTimer(startMicroSecond int64, maxMirocSecond int64) *BackoffTimer {
+	return &BackoffTimer{
+		startInterval:  startMicroSecond,
+		curInterval:    startMicroSecond,
+		maxInterval:    maxMirocSecond,
+		expire:         0,
+		useCanTryFirst: false,
+	}
+}
+
+func (t *BackoffTimer) OriginalSetting(ctx context.Context) {
+	t.curInterval = t.startInterval
+	t.useCanTryFirst = false
+	t.expire = 0
+}
+
+func (t *BackoffTimer) SuccessHit(ctx context.Context) {
+	// when connect or send successfully, call this once
+	if !t.useCanTryFirst {
+		log.Error(context.Background(), "first use canTry() to judge", map[string]interface{}{})
+	}
+	t.curInterval = t.startInterval
+	t.expire = 0
+	t.useCanTryFirst = false
+}
+
+func (t *BackoffTimer) FailedHit(ctx context.Context) {
+	// when connect or send failed, call this once
+	if !t.useCanTryFirst {
+		log.Error(context.Background(), "first use canTry() to judge", map[string]interface{}{})
+	}
+	t.expire = t.curInterval + time.Now().UnixMicro()
+	t.curInterval *= 2
+	if t.curInterval > t.maxInterval {
+		t.curInterval = t.maxInterval
+	}
+	t.useCanTryFirst = false
+}
+
+func (t *BackoffTimer) CanTry() bool {
+	// judge whether retry
+	// Should call CanTry before SuccessHit or FailedHit
+	t.useCanTryFirst = true
+	return time.Now().UnixMicro() > t.expire
+}

--- a/internal/raft/transport/backoff_timer_test.go
+++ b/internal/raft/transport/backoff_timer_test.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Linkall Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func Test_BackoffTimer(t *testing.T) {
+	timer := NewBackoffTimer(0.2e6, 0.6e6)
+
+	Convey("test backoff timer", t, func() {
+		ctx := context.Background()
+		So(timer.CanTry(), ShouldBeTrue)
+
+		timer.FailedHit(ctx)
+		So(timer.CanTry(), ShouldBeFalse)
+
+		time.Sleep(0.3e6 * time.Microsecond)
+		So(timer.CanTry(), ShouldBeTrue)
+
+		timer.FailedHit(ctx)
+		So(timer.CanTry(), ShouldBeFalse)
+
+		time.Sleep(0.3e6 * time.Microsecond)
+		So(timer.CanTry(), ShouldBeFalse)
+
+		time.Sleep(0.2e6 * time.Microsecond)
+		So(timer.CanTry(), ShouldBeTrue)
+
+		timer.FailedHit(ctx)
+		time.Sleep(0.5e6 * time.Microsecond)
+		So(timer.CanTry(), ShouldBeFalse)
+
+		time.Sleep(0.2e6 * time.Microsecond)
+		So(timer.CanTry(), ShouldBeTrue)
+
+		timer.SuccessHit(ctx)
+		So(timer.CanTry(), ShouldBeTrue)
+
+		timer.FailedHit(ctx)
+		time.Sleep(0.1e6 * time.Microsecond)
+		So(timer.CanTry(), ShouldBeFalse)
+
+		time.Sleep(0.2e6 * time.Microsecond)
+		So(timer.CanTry(), ShouldBeTrue)
+	})
+}

--- a/internal/raft/transport/backoff_timer_test.go
+++ b/internal/raft/transport/backoff_timer_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func Test_BackoffTimer(t *testing.T) {
-	timer := NewBackoffTimer(0.2e6, 0.6e6)
+	timer := NewBackoffTimer(200*time.Millisecond, 600*time.Millisecond)
 
 	Convey("test backoff timer", t, func() {
 		ctx := context.Background()
@@ -32,33 +32,33 @@ func Test_BackoffTimer(t *testing.T) {
 		timer.FailedHit(ctx)
 		So(timer.CanTry(), ShouldBeFalse)
 
-		time.Sleep(0.3e6 * time.Microsecond)
+		time.Sleep(300 * time.Millisecond)
 		So(timer.CanTry(), ShouldBeTrue)
 
 		timer.FailedHit(ctx)
 		So(timer.CanTry(), ShouldBeFalse)
 
-		time.Sleep(0.3e6 * time.Microsecond)
+		time.Sleep(300 * time.Millisecond)
 		So(timer.CanTry(), ShouldBeFalse)
 
-		time.Sleep(0.2e6 * time.Microsecond)
+		time.Sleep(200 * time.Millisecond)
 		So(timer.CanTry(), ShouldBeTrue)
 
 		timer.FailedHit(ctx)
-		time.Sleep(0.5e6 * time.Microsecond)
+		time.Sleep(500 * time.Millisecond)
 		So(timer.CanTry(), ShouldBeFalse)
 
-		time.Sleep(0.2e6 * time.Microsecond)
+		time.Sleep(200 * time.Millisecond)
 		So(timer.CanTry(), ShouldBeTrue)
 
 		timer.SuccessHit(ctx)
 		So(timer.CanTry(), ShouldBeTrue)
 
 		timer.FailedHit(ctx)
-		time.Sleep(0.1e6 * time.Microsecond)
+		time.Sleep(100 * time.Millisecond)
 		So(timer.CanTry(), ShouldBeFalse)
 
-		time.Sleep(0.2e6 * time.Microsecond)
+		time.Sleep(200 * time.Millisecond)
 		So(timer.CanTry(), ShouldBeTrue)
 	})
 }

--- a/internal/raft/transport/peer.go
+++ b/internal/raft/transport/peer.go
@@ -34,8 +34,8 @@ import (
 const (
 	defaultConnectTimeout   = 300 * time.Millisecond
 	defaultMessageChainSize = 32
-	initRetryMicroSeconds   = 2e6
-	maxRertyMicropSeconds   = 64e6
+	initRetryTime           = 2 * time.Second
+	maxRertyTime            = 8 * time.Second
 )
 
 type task struct {
@@ -50,7 +50,7 @@ type peer struct {
 	stream vsraftpb.RaftServer_SendMessageClient
 	closec chan struct{}
 	donec  chan struct{}
-	timer  *BackoffTimer
+	timer  BackoffTimer
 }
 
 // Make sure peer implements Multiplexer.
@@ -62,7 +62,7 @@ func newPeer(endpoint string, callback string) *peer {
 		taskc:  make(chan task, defaultMessageChainSize),
 		closec: make(chan struct{}),
 		donec:  make(chan struct{}),
-		timer:  NewBackoffTimer(initRetryMicroSeconds, maxRertyMicropSeconds),
+		timer:  NewBackoffTimer(initRetryTime, maxRertyTime),
 	}
 
 	go p.run(callback)

--- a/internal/raft/transport/peer_test.go
+++ b/internal/raft/transport/peer_test.go
@@ -168,6 +168,7 @@ func TestPeer(t *testing.T) {
 		msg := &raftpb.Message{
 			To: nodeID,
 		}
+		time.Sleep(time.Second)
 		srv.Stop()
 		time.Sleep(200 * time.Millisecond)
 		var count int64 = 0

--- a/internal/store/block/replica/replica.go
+++ b/internal/store/block/replica/replica.go
@@ -39,12 +39,13 @@ import (
 )
 
 const (
-	defaultHintCapacity    = 2
-	defaultTickInterval    = 100 * time.Millisecond
-	defaultElectionTick    = 10
-	defaultHeartbeatTick   = 3
-	defaultMaxSizePerMsg   = 4096
-	defaultMaxInflightMsgs = 256
+	defaultHintCapacity       = 2
+	defaultTickInterval       = 100 * time.Millisecond
+	defaultElectionTick       = 10
+	defaultHeartbeatTick      = 3
+	defaultMaxSizePerMsg      = 4096
+	defaultMaxInflightMsgs    = 256
+	defaultMaxUnreachableMsgs = 12
 )
 
 type Peer struct {

--- a/internal/store/block/replica/replica.go
+++ b/internal/store/block/replica/replica.go
@@ -39,13 +39,12 @@ import (
 )
 
 const (
-	defaultHintCapacity       = 2
-	defaultTickInterval       = 100 * time.Millisecond
-	defaultElectionTick       = 10
-	defaultHeartbeatTick      = 3
-	defaultMaxSizePerMsg      = 4096
-	defaultMaxInflightMsgs    = 256
-	defaultMaxUnreachableMsgs = 12
+	defaultHintCapacity    = 2
+	defaultTickInterval    = 100 * time.Millisecond
+	defaultElectionTick    = 10
+	defaultHeartbeatTick   = 3
+	defaultMaxSizePerMsg   = 4096
+	defaultMaxInflightMsgs = 256
 )
 
 type Peer struct {


### PR DESCRIPTION
<!--

Thank you for contributing to Vanus!

PR Title Format: 

feat/fix/refactor/docs/...: what's changed

Note: see https://github.com/linkall-labs/vanus/blob/main/CONTRIBUTING.md to know details about title format
-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem

There MUST be one line starting with "Issue Number:  ".

-->

Issue Number: close #xxx

### Problem Summary
When the communication of the store node fails, backoff is required to avoid performance degradation caused by repeated retries.

### What is changed and how does it work?
Add backoff timer mechanism and  modify retry logic.

### Check List

<!-- At least one of them must be included. -->

#### Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
