### PR TITLE
ci: make e2e trigger aware of scope and breaking notation

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,8 +12,12 @@ jobs:
     name: e2e
     if: |
       startsWith(github.event.pull_request.title, 'fix:') ||
+      startsWith(github.event.pull_request.title, 'fix(') ||
       startsWith(github.event.pull_request.title, 'feat:') ||
-      startsWith(github.event.pull_request.title, 'refactor:')
+      startsWith(github.event.pull_request.title, 'feat(') ||
+      startsWith(github.event.pull_request.title, 'feat!:') ||
+      startsWith(github.event.pull_request.title, 'refactor:') ||
+      startsWith(github.event.pull_request.title, 'refactor(')
     runs-on: ubuntu-latest
     env:
       VANUS_GATEWAY: 192.168.49.2:30001


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

### Problem Summary

The e2e trigger complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec, but it is currently unaware of scope and breaking notation.

### What is changed and how does it work?

### Check List

<!-- At least one of them must be included. -->

#### Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
