### PR TITLE
test: use vancehub/sink-display

### DIFF
--- a/test/yaml/display.yml
+++ b/test/yaml/display.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: quick-display
-          image: vancehub/display:1.0.0
+          image: vancehub/sink-display:latest
           imagePullPolicy: IfNotPresent
 ---
 apiVersion: v1
@@ -27,7 +27,7 @@ metadata:
 spec:
   ports:
     - port: 80
-      targetPort: 8080
+      targetPort: 8081
   selector:
     app: quick-display
   type: ClusterIP


### PR DESCRIPTION
### What problem does this PR solve?

`vancehub/display:1.0.0` is gone.

Issue Number: None

### Problem Summary

### What is changed and how does it work?

Use `vancehub/sink-display@latest` instead of `vancehub/display:1.0.0`.

### Check List

<!-- At least one of them must be included. -->

#### Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code
