### PR TITLE
convert_timezone function implemented

### DIFF
--- a/internal/primitive/transform/action/strings/convert_timezone.go
+++ b/internal/primitive/transform/action/strings/convert_timezone.go
@@ -1,0 +1,61 @@
+package strings
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/jmespath/go-jmespath"
+)
+
+// ConvertTimezone converts the time in a specific timezone from the source JSON path to time in another timezone,
+// and assigns the converted time to the target JSON path.
+func ConvertTimezone(input interface{}, sourceJsonPath, fromTimeZone, toTimeZone, targetJsonPath, dateTimeFormat string) (interface{}, error) {
+	// Use the default format if no format is specified.
+	if dateTimeFormat == "" {
+		dateTimeFormat = "2006-01-02 15:04:05"
+	}
+
+	// Parse the source JSON path to get the source time value.
+	sourceTime, err := jmespath.Search(sourceJsonPath, input)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if the source time value is a string.
+	sourceTimeString, ok := sourceTime.(string)
+	if !ok {
+		return nil, nil
+	}
+
+	// Parse the source time value.
+	sourceTimeParsed, err := time.ParseInLocation(dateTimeFormat, sourceTimeString, time.Local)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert the source time to the target timezone.
+	targetTimeParsed := sourceTimeParsed.In(timezoneFromString(fromTimeZone)).UTC()
+
+	// Convert the target time to the destination timezone.
+	targetTimeParsed = targetTimeParsed.In(timezoneFromString(toTimeZone))
+
+	// Format the target time value.
+	targetTimeString := targetTimeParsed.Format(dateTimeFormat)
+
+	// Update the target JSON path with the target time value.
+	return jmespath.Update(input, targetJsonPath, func(interface{}) (interface{}, error) {
+		return targetTimeString, nil
+	})
+}
+
+// timezoneFromString returns a *time.Location corresponding to the given timezone string.
+func timezoneFromString(timezone string) *time.Location {
+	if timezone == "" {
+		return time.UTC
+	}
+	location, err := time.LoadLocation(timezone)
+	if err != nil {
+		location = time.UTC
+	}
+	return location
+}

--- a/internal/primitive/transform/action/strings/convert_timezone_test.go
+++ b/internal/primitive/transform/action/strings/convert_timezone_test.go
@@ -1,0 +1,123 @@
+package strings
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestConvertTimezone(t *testing.T) {
+	type args struct {
+		source         string
+		fromTimezone   string
+		toTimezone     string
+		targetJsonPath string
+		dateTimeFormat string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		inputJSON  string
+		wantJSON   string
+		wantErr    bool
+	}{
+		{
+			name: "Convert from UTC to CET",
+			args: args{
+				source:         "$.data.appinfoA",
+				fromTimezone:   "UTC",
+				toTimezone:     "CET",
+				targetJsonPath: "$.data.appinfoB",
+			},
+			inputJSON: `{
+				"specversion": "1.0",
+				"type": "com.example.someevent",
+				"source": "/mycontext",
+				"subject": null,
+				"id": "C234-1234-1234",
+				"time": "2018-04-05T17:31:00Z",
+				"comexampleextension1": "value",
+				"comexampleothervalue": 5,
+				"datacontenttype": "application/json",
+				"data": {
+					"appinfoA": "2021-08-29 12:01:10"
+				}
+			}`,
+			wantJSON: `{
+				"specversion": "1.0",
+				"type": "com.example.someevent",
+				"source": "/mycontext",
+				"subject": null,
+				"id": "C234-1234-1234",
+				"time": "2018-04-05T17:31:00Z",
+				"comexampleextension1": "value",
+				"comexampleothervalue": 5,
+				"datacontenttype": "application/json",
+				"data": {
+					"appinfoA": "2021-08-29 12:01:10",
+					"appinfoB": "2021-08-29 10:01:10"
+				}
+			}`,
+		},
+		{
+			name: "Convert from UTC to Asia/Kolkata",
+			args: args{
+				source:         "$.data.appinfoA",
+				fromTimezone:   "UTC",
+				toTimezone:     "Asia/Kolkata",
+				targetJsonPath: "$.data.appinfoB",
+			},
+			inputJSON: `{
+				"specversion": "1.0",
+				"type": "com.example.someevent",
+				"source": "/mycontext",
+				"subject": null,
+				"id": "C234-1234-1234",
+				"time": "2018-04-05T17:31:00Z",
+				"comexampleextension1": "value",
+				"comexampleothervalue": 5,
+				"datacontenttype": "application/json",
+				"data": {
+					"appinfoA": "2021-08-29 12:01:10"
+				}
+			}`,
+			wantJSON: `{
+				"specversion": "1.0",
+				"type": "com.example.someevent",
+				"source": "/mycontext",
+				" subject": null,
+				"id": "C234-1234-1234",
+				"time": "2018-04-05T17:31:00Z",
+				"comexampleextension1": "value",
+				"comexampleothervalue": 5,
+				"datacontenttype": "application/json",
+				"data": {
+					"appinfoA": "2021-08-29 12:01:10",
+					"appinfoB": "2021-08-29 17:31:10"
+				}
+			}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var input map[string]interface{}
+			err := json.Unmarshal([]byte(tt.inputJSON), &input)
+			if err != nil {
+				t.Errorf("ConvertTimezone() error = %v", err)
+				return
+			}
+			var want map[string]interface{}
+			err = json.Unmarshal([]byte(tt.wantJSON), &want)
+			if err != nil {
+				t.Errorf("ConvertTimezone() error = %v", err)
+				return
+			}
+			if err := ConvertTimezone(input, tt.args.source, tt.args.fromTimezone, tt.args.toTimezone, tt.args.targetJsonPath, tt.args.dateTimeFormat); (err != nil) != tt.wantErr {
+				t.Errorf("ConvertTimezone() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(input, want) {
+				t.Errorf("ConvertTimezone() got = %v, want %v", input, want)
+			}
+		})
+	}
+}

--- a/internal/primitive/transform/runtime/init.go
+++ b/internal/primitive/transform/runtime/init.go
@@ -26,6 +26,8 @@ import (
 )
 
 func init() {
+	// Register the convert_timezone function by calling the RegisterStringAction function:
+	registry.RegisterStringAction("convert_timezone", strings.ConvertTimezone)
 	for _, fn := range []newAction{
 		// struct
 		structs.NewCreateAction,
@@ -66,4 +68,5 @@ func init() {
 			panic(err)
 		}
 	}
+	 
 }


### PR DESCRIPTION
<!--

Thank you for contributing to Vanus!

PR Title Format: 

feat/fix/refactor/docs/...: what's changed

Note: see https://github.com/linkall-labs/vanus/blob/main/CONTRIBUTING.md to know details about title format
-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem

There MUST be one line starting with "Issue Number:  ".

-->

Issue Number: close #438 

### Problem Summary
The function is used to convert the time in a specific TimeZone from the source JSON path to time in another TimeZone, and assign the converted time to a target JSON path.
The time format will be yyyy-mm-dd HH:MM:SS if users don't specify it.

### What is changed and how does it work?
Changed `convert_timezone.go` under `internal/primitive/transform/action/strings`

### Check List

<!-- At least one of them must be included. -->

#### Tests

- [ ] Unit test

