### PR TITLE
feat: implement function "today 

### DIFF
--- a/internal/primitive/transform/action/datetime/today.go
+++ b/internal/primitive/transform/action/datetime/today.go
@@ -1,0 +1,33 @@
+// Copyright 2022 Linkall Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datetime
+
+import (
+	"github.com/linkall-labs/vanus/internal/primitive/transform/action"
+	"github.com/linkall-labs/vanus/internal/primitive/transform/arg"
+	"github.com/linkall-labs/vanus/internal/primitive/transform/function"
+)
+
+// NewTodayAction ["today", "path", "timeZone"]
+func NewTodayAction() action.Action {
+	a := &action.SourceTargetSameAction{}
+	a.CommonAction = action.CommonAction{
+		ActionName:  "TODAY",
+		FixedArgs:   []arg.TypeList{arg.EventList},
+		VariadicArg: arg.All,
+		Fn:          function.TodayFunction,
+	}
+	return a
+}

--- a/internal/primitive/transform/action/datetime/today_test.go
+++ b/internal/primitive/transform/action/datetime/today_test.go
@@ -1,0 +1,75 @@
+// Copyright 2022 Linkall Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datetime_test
+
+import (
+	"testing"
+
+	cetest "github.com/cloudevents/sdk-go/v2/test"
+	"github.com/linkall-labs/vanus/internal/primitive/transform/action/datetime"
+	"github.com/linkall-labs/vanus/internal/primitive/transform/context"
+	"github.com/linkall-labs/vanus/internal/primitive/transform/runtime"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestTodayAction(t *testing.T) {
+	funcName := datetime.NewTodayAction().Name()
+	Convey("test today date", t, func() {
+		Convey("test utc time with default time zone", func() {
+			e := cetest.MinEvent()
+			e.SetExtension("test", "2022-11-15T15:41:25Z")
+			a, err := runtime.NewAction([]interface{}{funcName, "$.test"})
+			So(err, ShouldBeNil)
+			err = a.Execute(&context.EventContext{
+				Event: &e,
+			})
+			So(err, ShouldBeNil)
+			So(e.Extensions()["test"], ShouldEqual, "2022-11-15")
+		})
+		Convey("test with time zone that has same date", func() {
+			e := cetest.MinEvent()
+			e.SetExtension("test", "2022-11-15T15:41:25Z")
+			a, err := runtime.NewAction([]interface{}{funcName, "$.test", "EST"})
+			So(err, ShouldBeNil)
+			err = a.Execute(&context.EventContext{
+				Event: &e,
+			})
+			So(err, ShouldBeNil)
+			So(e.Extensions()["test"], ShouldEqual, "2022-11-15")
+		})
+		Convey("test utc time with time zone that has the next date", func() {
+			e := cetest.MinEvent()
+			e.SetExtension("test", "2022-11-15T23:59:00Z")
+			a, err := runtime.NewAction([]interface{}{funcName, "$.test", "Asia/Kolkata"})
+			So(err, ShouldBeNil)
+			err = a.Execute(&context.EventContext{
+				Event: &e,
+			})
+			So(err, ShouldBeNil)
+			So(e.Extensions()["test"], ShouldEqual, "2022-11-16")
+		})
+		Convey("test utc time with time zone that has the previous date", func() {
+			e := cetest.MinEvent()
+			e.SetExtension("test", "2022-11-15T00:59:00Z")
+			a, err := runtime.NewAction([]interface{}{funcName, "$.test", "America/Chicago"})
+			So(err, ShouldBeNil)
+			err = a.Execute(&context.EventContext{
+				Event: &e,
+			})
+			So(err, ShouldBeNil)
+			So(e.Extensions()["test"], ShouldEqual, "2022-11-14")
+		})
+	})
+}

--- a/internal/primitive/transform/function/datatime_functions.go
+++ b/internal/primitive/transform/function/datatime_functions.go
@@ -60,3 +60,24 @@ var UnixTimeFormatFunction = function{
 		return t.In(loc).Format(format), nil
 	},
 }
+
+var TodayFunction = function{
+	name:         "TODAY",
+	fixedArgs:    []common.Type{common.String},
+	variadicArgs: common.TypePtr(common.String),
+	fn: func(args []interface{}) (interface{}, error) {
+		t, err := time.ParseInLocation(time.RFC3339, args[0].(string), time.UTC)
+		if err != nil {
+			return nil, err
+		}
+		loc := time.UTC
+		if len(args) > 1 && args[1].(string) != "" {
+			loc, err = time.LoadLocation(args[1].(string))
+			if err != nil {
+				return nil, err
+			}
+		}
+		format := util.GetYMDFormat()
+		return t.In(loc).Format(format), nil
+	},
+}

--- a/internal/primitive/transform/function/util/time.go
+++ b/internal/primitive/transform/function/util/time.go
@@ -46,3 +46,8 @@ func ConvertFormat2Go(format string) string {
 	}
 	return buffer.String()
 }
+
+// GetYMDFormat returns yyyy-mm-dd format.
+func GetYMDFormat() string {
+	return ConvertFormat2Go("Y-m-d")
+}

--- a/internal/primitive/transform/runtime/init.go
+++ b/internal/primitive/transform/runtime/init.go
@@ -42,6 +42,7 @@ func init() {
 		// datetime
 		datetime.NewDateFormatAction,
 		datetime.NewUnixTimeFormatAction,
+		datetime.NewTodayAction,
 		// string
 		strings.NewJoinAction,
 		strings.NewUpperAction,


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close https://github.com/vanus-labs/vanus/issues/462

### Problem Summary
The function is used to get the current date(format: YYYY-MM-DD) in a specific TimeZone. And assign it to the target JSON path.
The Time Zone will be UTC if users don't specify it.

### What is changed and how does it work?
* adds a new 'function' called `today`
* reads the time info from data and return it in YYYY-MM-DD format after converting it to the passed/default timezone

### Check List

#### Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
