### PR TITLE
feat: imple function extract between positions

### DIFF
--- a/internal/primitive/transform/action/strings/extract_between_positions.go
+++ b/internal/primitive/transform/action/strings/extract_between_positions.go
@@ -1,0 +1,72 @@
+// Copyright 2023 Linkall Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strings
+
+import (
+	"fmt"
+
+	"github.com/vanus-labs/vanus/internal/primitive/transform/action"
+	"github.com/vanus-labs/vanus/internal/primitive/transform/arg"
+	"github.com/vanus-labs/vanus/internal/primitive/transform/common"
+	"github.com/vanus-labs/vanus/internal/primitive/transform/context"
+)
+
+type extractBetweenPositionsAction struct {
+	action.CommonAction
+}
+
+// NewExtractBetweenPositionsAction ["extract_between_positions",
+// "sourceJSONPath", "targetJsonPath", "startPosition", "endPosition"]
+func NewExtractBetweenPositionsAction() action.Action {
+	return &extractBetweenPositionsAction{
+		CommonAction: action.CommonAction{
+			ActionName: "EXTRACT_BETWEEN_POSITIONS",
+			FixedArgs:  []arg.TypeList{arg.EventList, arg.EventList, arg.All, arg.All},
+		},
+	}
+}
+
+func (a *extractBetweenPositionsAction) Init(args []arg.Arg) error {
+	a.TargetArg = args[1]
+	a.Args = []arg.Arg{args[0]}
+	a.Args = append(a.Args, args[2:]...)
+	a.ArgTypes = []common.Type{common.String, common.Int, common.Int}
+	return nil
+}
+
+func (a *extractBetweenPositionsAction) Execute(ceCtx *context.EventContext) error {
+	args, err := a.RunArgs(ceCtx)
+	if err != nil {
+		return err
+	}
+
+	sourceJSONPath, _ := args[0].(string)
+	startPosition, _ := args[1].(int)
+	endPosition, _ := args[2].(int)
+
+	if startPosition > len(sourceJSONPath) {
+		return fmt.Errorf("start position must be equal or less than the length of the string")
+	}
+	if startPosition <= 0 {
+		return fmt.Errorf("start position must be more than zero")
+	}
+	if endPosition > len(sourceJSONPath) {
+		return fmt.Errorf("end position must be equal or less than the length of the string")
+	}
+	if startPosition > endPosition {
+		return fmt.Errorf("start position must be be equal or less than end position")
+	}
+	return a.TargetArg.SetValue(ceCtx, sourceJSONPath[startPosition-1:endPosition])
+}

--- a/internal/primitive/transform/action/strings/extract_between_positions_test.go
+++ b/internal/primitive/transform/action/strings/extract_between_positions_test.go
@@ -1,0 +1,144 @@
+// Copyright 2023 Linkall Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strings_test
+
+import (
+	"testing"
+
+	cetest "github.com/cloudevents/sdk-go/v2/test"
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/vanus-labs/vanus/internal/primitive/transform/action/strings"
+	"github.com/vanus-labs/vanus/internal/primitive/transform/context"
+	"github.com/vanus-labs/vanus/internal/primitive/transform/runtime"
+)
+
+func TestExtractBetweenPositionsAction(t *testing.T) {
+	funcName := strings.NewExtractBetweenPositionsAction().Name()
+
+	Convey("test: Positive testcase", t, func() {
+		a, err := runtime.NewAction([]interface{}{funcName, "$.data.appinfoA", "$.data.appinfoB", 2, 4})
+		So(err, ShouldBeNil)
+		e := cetest.MinEvent()
+		data := map[string]interface{}{
+			"appinfoA": "hello world!",
+		}
+		ceCtx := &context.EventContext{
+			Event: &e,
+			Data:  data,
+		}
+		err = a.Execute(ceCtx)
+		So(err, ShouldBeNil)
+		res, ok := data["appinfoB"]
+		So(ok, ShouldBeTrue)
+		So(res, ShouldResemble, "ell")
+	})
+
+	Convey("test: Positive testcase - extract positions on edges", t, func() {
+		a, err := runtime.NewAction([]interface{}{funcName, "$.data.appinfoA", "$.data.appinfoB", 1, 12})
+		So(err, ShouldBeNil)
+		e := cetest.MinEvent()
+		data := map[string]interface{}{
+			"appinfoA": "hello world!",
+		}
+		ceCtx := &context.EventContext{
+			Event: &e,
+			Data:  data,
+		}
+		err = a.Execute(ceCtx)
+		So(err, ShouldBeNil)
+		res, ok := data["appinfoB"]
+		So(ok, ShouldBeTrue)
+		So(res, ShouldResemble, "hello world!")
+	})
+
+	Convey("test: Positive testcase - extract positions are equal", t, func() {
+		a, err := runtime.NewAction([]interface{}{funcName, "$.data.appinfoA", "$.data.appinfoB", 1, 1})
+		So(err, ShouldBeNil)
+		e := cetest.MinEvent()
+		data := map[string]interface{}{
+			"appinfoA": "hello world!",
+		}
+		ceCtx := &context.EventContext{
+			Event: &e,
+			Data:  data,
+		}
+		err = a.Execute(ceCtx)
+		So(err, ShouldBeNil)
+		res, ok := data["appinfoB"]
+		So(ok, ShouldBeTrue)
+		So(res, ShouldResemble, "h")
+	})
+
+	Convey("test: Negative testcase - start position more than the length of the string", t, func() {
+		a, err := runtime.NewAction([]interface{}{funcName, "$.data.appinfoA", "$.data.appinfoB", 13, 13})
+		So(err, ShouldBeNil)
+		e := cetest.MinEvent()
+		data := map[string]interface{}{
+			"appinfoA": "hello world!",
+		}
+		ceCtx := &context.EventContext{
+			Event: &e,
+			Data:  data,
+		}
+		err = a.Execute(ceCtx)
+		So(err.Error(), ShouldEqual, "start position must be equal or less than the length of the string")
+	})
+
+	Convey("test: Negative testcase - start position less than one", t, func() {
+		a, err := runtime.NewAction([]interface{}{funcName, "$.data.appinfoA", "$.data.appinfoB", 0, 13})
+		So(err, ShouldBeNil)
+		e := cetest.MinEvent()
+		data := map[string]interface{}{
+			"appinfoA": "hello world!",
+		}
+		ceCtx := &context.EventContext{
+			Event: &e,
+			Data:  data,
+		}
+		err = a.Execute(ceCtx)
+		So(err.Error(), ShouldEqual, "start position must be more than zero")
+	})
+
+	Convey("test: Negative testcase - end position bigger than the length of the string", t, func() {
+		a, err := runtime.NewAction([]interface{}{funcName, "$.data.appinfoA", "$.data.appinfoB", 5, 13})
+		So(err, ShouldBeNil)
+		e := cetest.MinEvent()
+		data := map[string]interface{}{
+			"appinfoA": "hello world!",
+		}
+		ceCtx := &context.EventContext{
+			Event: &e,
+			Data:  data,
+		}
+		err = a.Execute(ceCtx)
+		So(err.Error(), ShouldEqual, "end position must be equal or less than the length of the string")
+	})
+
+	Convey("test: Negative testcase - start position bigger than end position", t, func() {
+		a, err := runtime.NewAction([]interface{}{funcName, "$.data.appinfoA", "$.data.appinfoB", 5, 3})
+		So(err, ShouldBeNil)
+		e := cetest.MinEvent()
+		data := map[string]interface{}{
+			"appinfoA": "hello world!",
+		}
+		ceCtx := &context.EventContext{
+			Event: &e,
+			Data:  data,
+		}
+		err = a.Execute(ceCtx)
+		So(err.Error(), ShouldEqual, "start position must be be equal or less than end position")
+	})
+}

--- a/internal/primitive/transform/runtime/init.go
+++ b/internal/primitive/transform/runtime/init.go
@@ -59,6 +59,7 @@ func init() {
 		strings.NewSplitWithDelimiterAction,
 		strings.NewSplitBetweenPositionsAction,
 		strings.NewSplitFromStartAction,
+		strings.NewExtractBetweenPositionsAction,
 		// condition
 		condition.NewConditionIfAction,
 		// array


### PR DESCRIPTION
<!--

Thank you for contributing to Vanus!

PR Title Format: 

feat/fix/refactor/docs/...: what's changed

Note: see https://github.com/vanus-labs/vanus/blob/main/CONTRIBUTING.md to know details about title format

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem

There MUST be one line starting with "Issue Number:  ".

-->

Issue Number: close #539

### Problem Summary

The function is used to extract value between the starting numeric position and end numeric position from the source JSON path. Then assign the value to the target JSON path.

### What is changed and how does it work?

1. Added `NewExtractBetweenPositionsAction()` constructor which returns `extractBetweenPositionsAction`
2. Implemented custom `Init()` and `Execute()` to handle 4 args.
3. Added implementation of the extraction In `Execute()`. Included four error checks.
4. Added unit tests with 7 test cases.

### Check List

<!-- At least one of them must be included. -->

#### Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
