### PR TITLE
fix: convert rpcerr to ErrorType

### DIFF
--- a/pkg/cluster/auth.go
+++ b/pkg/cluster/auth.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/vanus-labs/vanus/pkg/cluster/raw_client"
+	"github.com/vanus-labs/vanus/pkg/errors"
 	ctrlpb "github.com/vanus-labs/vanus/proto/pkg/controller"
 	metapb "github.com/vanus-labs/vanus/proto/pkg/meta"
 )
@@ -31,7 +32,7 @@ type authService struct {
 func (a *authService) GetUserRole(ctx context.Context, user string) ([]*metapb.UserRole, error) {
 	resp, err := a.client.GetUserRole(ctx, &ctrlpb.GetUserRoleRequest{UserIdentifier: user})
 	if err != nil {
-		return nil, err
+		return nil, errors.To(err)
 	}
 	return resp.GetUserRole(), nil
 }
@@ -39,7 +40,7 @@ func (a *authService) GetUserRole(ctx context.Context, user string) ([]*metapb.U
 func (a *authService) GetUserByToken(ctx context.Context, token string) (string, error) {
 	user, err := a.client.GetUserByToken(ctx, wrapperspb.String(token))
 	if err != nil {
-		return "", err
+		return "", errors.To(err)
 	}
 	return user.GetValue(), nil
 }

--- a/pkg/cluster/eventbus.go
+++ b/pkg/cluster/eventbus.go
@@ -44,14 +44,14 @@ func (es *eventbusService) GetEventbusByName(ctx context.Context, ns, name strin
 
 	pb, err := es.nsSvc.GetNamespaceByName(ctx, ns)
 	if err != nil {
-		return nil, err
+		return nil, errors.To(err)
 	}
 	eb, err := es.client.GetEventbusWithHumanFriendly(ctx, &ctrlpb.GetEventbusWithHumanFriendlyRequest{
 		NamespaceId:  pb.Id,
 		EventbusName: name,
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.To(err)
 	}
 
 	// es.cache.Store(key, eb) unmask when dirty cache is resolved
@@ -66,7 +66,7 @@ func (es *eventbusService) GetEventbus(ctx context.Context, id uint64) (*meta.Ev
 
 	eb, err := es.client.GetEventbus(ctx, wrapperspb.UInt64(id))
 	if err != nil {
-		return nil, err
+		return nil, errors.To(err)
 	}
 
 	// es.cache.Store(id, eb) unmask when dirty cache is resolved
@@ -93,20 +93,21 @@ func (es *eventbusService) CreateSystemEventbusIfNotExist(ctx context.Context, n
 
 	nsPb, err := es.nsSvc.GetSystemNamespace(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errors.To(err)
 	}
 
-	return es.client.CreateSystemEventbus(ctx, &ctrlpb.CreateEventbusRequest{
+	eventbus, err := es.client.CreateSystemEventbus(ctx, &ctrlpb.CreateEventbusRequest{
 		Name:        name,
 		LogNumber:   int32(defaultSystemEventbusEventlog),
 		Description: desc,
 		NamespaceId: nsPb.Id,
 	})
+	return eventbus, errors.To(err)
 }
 
 func (es *eventbusService) Delete(ctx context.Context, id uint64) error {
 	_, err := es.client.DeleteEventbus(ctx, wrapperspb.UInt64(id))
-	return err
+	return errors.To(err)
 }
 
 func (es *eventbusService) RawClient() ctrlpb.EventbusControllerClient {

--- a/pkg/cluster/namespace.go
+++ b/pkg/cluster/namespace.go
@@ -16,10 +16,12 @@ package cluster
 
 import (
 	"context"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 	"sync"
 
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	"github.com/vanus-labs/vanus/pkg/cluster/raw_client"
+	"github.com/vanus-labs/vanus/pkg/errors"
 	ctrlpb "github.com/vanus-labs/vanus/proto/pkg/controller"
 	metapb "github.com/vanus-labs/vanus/proto/pkg/meta"
 )
@@ -41,7 +43,7 @@ func (ns *namespaceService) GetNamespace(ctx context.Context, id uint64) (*metap
 	}
 	n, err := ns.client.GetNamespace(ctx, &ctrlpb.GetNamespaceRequest{Id: id})
 	if err != nil {
-		return nil, err
+		return nil, errors.To(err)
 	}
 	// ns.cache.Store(id, n) unmask when dirty cache is resolved
 	return n, nil
@@ -62,7 +64,7 @@ func (ns *namespaceService) GetNamespaceByName(ctx context.Context, name string)
 	}
 	n, err := ns.client.GetNamespaceWithHumanFriendly(ctx, wrapperspb.String(name))
 	if err != nil {
-		return nil, err
+		return nil, errors.To(err)
 	}
 	// ns.cache.Store(name, n) unmask when dirty cache is resolved
 	return n, nil

--- a/pkg/cluster/trigger.go
+++ b/pkg/cluster/trigger.go
@@ -8,6 +8,7 @@ import (
 	metapb "github.com/vanus-labs/vanus/proto/pkg/meta"
 
 	"github.com/vanus-labs/vanus/pkg/cluster/raw_client"
+	"github.com/vanus-labs/vanus/pkg/errors"
 )
 
 type triggerService struct {
@@ -27,5 +28,6 @@ func (es *triggerService) RegisterHeartbeat(ctx context.Context, interval time.D
 }
 
 func (es *triggerService) GetSubscription(ctx context.Context, id uint64) (*metapb.Subscription, error) {
-	return es.client.GetSubscription(ctx, &ctrlpb.GetSubscriptionRequest{Id: id})
+	subscription, err := es.client.GetSubscription(ctx, &ctrlpb.GetSubscriptionRequest{Id: id})
+	return subscription, errors.To(err)
 }

--- a/pkg/errors/utils.go
+++ b/pkg/errors/utils.go
@@ -66,6 +66,11 @@ func Is(err error, target error) bool {
 	return errType != nil && errType.Code == targetType.Code
 }
 
+func To(err error) *ErrorType {
+	et, _ := FromError(err)
+	return et
+}
+
 func FromError(err error) (*ErrorType, bool) {
 	if err == nil {
 		return nil, true


### PR DESCRIPTION
### What problem does this PR solve?

convert rpcerr to ErrorType

Before modification:

```
controller       | time="2023-03-28T11:37:04Z" level=error msg="failed to create RetryEventbus, exit" error="rpc error: code = Unknown desc = {\"description\":\"volume instance not found\",\"message\":\"\",\"code\":9405}"
```

After modification

```
controller       | time="2023-03-28T11:56:22Z" level=error msg="failed to create RetryEventbus, exit" error="{\"description\": \"volume instance not found\",\"code\":9405}"
```

Issue Number: close #xxx

### Problem Summary

### What is changed and how does it work?

### Check List

<!-- At least one of them must be included. -->

#### Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
