### PR TITLE
fix: schedule disabled subscription when trigger worker step down

### DIFF
--- a/internal/controller/trigger/worker/worker.go
+++ b/internal/controller/trigger/worker/worker.go
@@ -20,6 +20,9 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
 	"github.com/vanus-labs/vanus/internal/controller/trigger/metadata"
 	"github.com/vanus-labs/vanus/internal/controller/trigger/subscription"
 	"github.com/vanus-labs/vanus/internal/convert"
@@ -29,8 +32,6 @@ import (
 	"github.com/vanus-labs/vanus/observability/log"
 	"github.com/vanus-labs/vanus/pkg/errors"
 	"github.com/vanus-labs/vanus/proto/pkg/trigger"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 type TriggerWorker interface {
@@ -146,6 +147,11 @@ func (tw *triggerWorker) handler(ctx context.Context, subscriptionID vanus.ID) e
 				return err
 			}
 		}
+		log.Info().
+			Str(log.KeyTriggerWorkerAddr, tw.info.Addr).
+			Stringer(log.KeySubscriptionID, subscriptionID).
+			Msg("trigger worker remove a subscription for disable")
+		tw.assignSubscriptionIDs.Delete(subscriptionID)
 		return nil
 	}
 	offsets, err := tw.subscriptionManager.GetOrSaveOffset(ctx, subscriptionID)


### PR DESCRIPTION
<!--

Thank you for contributing to Vanus!

PR Title Format: 

feat/fix/refactor/docs/...: what's changed

Note: see https://github.com/vanus-labs/vanus/blob/main/CONTRIBUTING.md to know details about title format

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem

There MUST be one line starting with "Issue Number:  ".

-->

Issue Number: close #xxx

### Problem Summary

when  disable a subscription, the controller will send a stop command to trigger worker and modify the subscription to disabled, but it doesn't clean the memory, when the trigger worker leaves, it will schedule the subscription on the trigger worker, then the subscription will become pending and running

### What is changed and how does it work?

### Check List

<!-- At least one of them must be included. -->

#### Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
