### PR TITLE
feat: implement function "today"

### DIFF
--- a/internal/primitive/transform/action/datetime/today.go
+++ b/internal/primitive/transform/action/datetime/today.go
@@ -68,7 +68,7 @@ func (a *todayAction) Execute(ceCtx *context.EventContext) error {
 		}
 	}
 	t := time.Now()
-	today := t.In(loc).Format(time.DateOnly)
+	today := t.In(loc).Format("2006-01-02")
 
 	return a.TargetArg.SetValue(ceCtx, today)
 }

--- a/internal/primitive/transform/action/datetime/today.go
+++ b/internal/primitive/transform/action/datetime/today.go
@@ -1,0 +1,74 @@
+// Copyright 2023 Linkall Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datetime
+
+import (
+	"time"
+
+	"github.com/vanus-labs/vanus/internal/primitive/transform/action"
+	"github.com/vanus-labs/vanus/internal/primitive/transform/arg"
+	"github.com/vanus-labs/vanus/internal/primitive/transform/common"
+	"github.com/vanus-labs/vanus/internal/primitive/transform/context"
+	// "github.com/vanus-labs/vanus/internal/primitive/transform/function"
+)
+
+type todayAction struct {
+	action.CommonAction
+}
+
+// NewTodayAction [ "targetJsonPath", "TimeZone"].
+func NewTodayAction() action.Action {
+	return &todayAction{
+		CommonAction: action.CommonAction{
+			ActionName:  "TODAY",
+			FixedArgs:   []arg.TypeList{arg.EventList},
+			VariadicArg: arg.TypeList{arg.Constant},
+		},
+	}
+}
+
+func (a *todayAction) Init(args []arg.Arg) error {
+	a.TargetArg = args[0]
+	if len(args) == 1 {
+		utc, err := arg.NewArg(time.UTC.String())
+		if err != nil {
+			return err
+		}
+		args = append(args, utc)
+	}
+	a.Args = args[1:]
+	a.ArgTypes = []common.Type{common.String}
+	return nil
+}
+
+func (a *todayAction) Execute(ceCtx *context.EventContext) error {
+	args, err := a.RunArgs(ceCtx)
+	if err != nil {
+		return err
+	}
+
+	loc := new(time.Location)
+	if len(args) > 0 && args[0].(string) != "" {
+		var err error
+		loc, err = time.LoadLocation(args[0].(string))
+		if err != nil {
+			return err
+		}
+	}
+	t := time.Now()
+	today := t.In(loc).Format(time.DateOnly)
+
+	return a.TargetArg.SetValue(ceCtx, today)
+}

--- a/internal/primitive/transform/action/datetime/today_test.go
+++ b/internal/primitive/transform/action/datetime/today_test.go
@@ -1,0 +1,56 @@
+// Copyright 2022 Linkall Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datetime_test
+
+import (
+	"testing"
+	"time"
+
+	cetest "github.com/cloudevents/sdk-go/v2/test"
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/vanus-labs/vanus/internal/primitive/transform/action/datetime"
+	"github.com/vanus-labs/vanus/internal/primitive/transform/context"
+	"github.com/vanus-labs/vanus/internal/primitive/transform/runtime"
+)
+
+func TestToday(t *testing.T) {
+	funcName := datetime.NewTodayAction().Name()
+	Convey("test today", t, func() {
+		Convey("test default time zone", func() {
+			e := cetest.MinEvent()
+			// e.SetExtension("test", "2022-11-15T15:41:25Z")
+			a, err := runtime.NewAction([]interface{}{funcName, "$.test"})
+			So(err, ShouldBeNil)
+			err = a.Execute(&context.EventContext{
+				Event: &e,
+			})
+			So(err, ShouldBeNil)
+			So(e.Extensions()["test"], ShouldEqual, time.Now().In(time.UTC).Format(time.DateOnly))
+		})
+		Convey("test  time zone", func() {
+			e := cetest.MinEvent()
+			// e.SetExtension("test", "2022-11-15T15:41:25Z")
+			a, err := runtime.NewAction([]interface{}{funcName, "$.test", "Europe/Berlin"})
+			So(err, ShouldBeNil)
+			err = a.Execute(&context.EventContext{
+				Event: &e,
+			})
+			loc, _ := time.LoadLocation("Europe/Berlin")
+			So(err, ShouldBeNil)
+			So(e.Extensions()["test"], ShouldEqual, time.Now().In(loc).Format(time.DateOnly))
+		})
+	})
+}

--- a/internal/primitive/transform/action/datetime/today_test.go
+++ b/internal/primitive/transform/action/datetime/today_test.go
@@ -38,7 +38,7 @@ func TestToday(t *testing.T) {
 				Event: &e,
 			})
 			So(err, ShouldBeNil)
-			So(e.Extensions()["test"], ShouldEqual, time.Now().In(time.UTC).Format(time.DateOnly))
+			So(e.Extensions()["test"], ShouldEqual, time.Now().In(time.UTC).Format("2006-01-02"))
 		})
 		Convey("test  time zone", func() {
 			e := cetest.MinEvent()
@@ -50,7 +50,7 @@ func TestToday(t *testing.T) {
 			})
 			loc, _ := time.LoadLocation("Europe/Berlin")
 			So(err, ShouldBeNil)
-			So(e.Extensions()["test"], ShouldEqual, time.Now().In(loc).Format(time.DateOnly))
+			So(e.Extensions()["test"], ShouldEqual, time.Now().In(loc).Format("2006-01-02"))
 		})
 	})
 }

--- a/internal/primitive/transform/runtime/init.go
+++ b/internal/primitive/transform/runtime/init.go
@@ -43,6 +43,7 @@ func init() {
 		datetime.NewDateFormatAction,
 		datetime.NewUnixTimeFormatAction,
 		datetime.NewConvertTimezoneAction,
+		datetime.NewTodayAction,
 		// string
 		strings.NewJoinAction,
 		strings.NewUpperAction,


### PR DESCRIPTION
<!--

Thank you for contributing to Vanus!

PR Title Format: 

feat/fix/refactor/docs/...: what's changed

Note: see https://github.com/vanus-labs/vanus/blob/main/CONTRIBUTING.md to know details about title format

-->

### What problem does this PR solve?

Issue Number: close https://github.com/vanus-labs/vanus/issues/462
<!--

Please create an issue first to describe the problem

There MUST be one line starting with "Issue Number:  ".

-->

Issue Number: close #xxx

### Problem Summary

The function is used to get the current date(format: YYYY-MM-DD) in a specific TimeZone. And assign it to the target JSON path.
The Time Zone will be UTC if users don't specify it.


### What is changed and how does it work?
- adds a new 'function' called today
reads the time info from data and return it in YYYY-MM-DD format after converting it to the passed/default 
- timezone
### Check List

<!-- At least one of them must be included. -->

#### Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
