### PR TITLE
fix: template does not follow RFC3339 time format

### DIFF
--- a/pkg/template/json/helper.go
+++ b/pkg/template/json/helper.go
@@ -60,7 +60,9 @@ func writeJSONInJSONString(w io.Writer, v any) error {
 
 func writeInJSONString(w io.Writer, v any) error {
 	switch v.(type) {
-	case nil, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, string:
+	case nil, bool, int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64, string, time.Time:
 		var ba [32]byte // underlying array of byte buffer in stack.
 		buf := unsafe.Slice((*byte)(noescape(unsafe.Pointer(&ba[0]))), len(ba))
 		data := appendInJSONString(buf[:0], v)
@@ -104,6 +106,8 @@ func appendInJSONString(dst []byte, v any) []byte {
 		return generate.AppendFloat64(dst, val)
 	case string:
 		return generate.AppendRawString(dst, val)
+	case time.Time:
+		return val.AppendFormat(dst, time.RFC3339)
 	}
 	// TODO
 	return nil

--- a/pkg/template/json/helper.go
+++ b/pkg/template/json/helper.go
@@ -19,18 +19,21 @@ import (
 	"io"
 	"runtime"
 	"sync"
+	"time"
 	"unsafe"
 
 	// third-party libraries.
 	"github.com/ohler55/ojg/oj"
 
-	// this project.
+	// first-party libraries.
 	"github.com/vanus-labs/vanus/lib/json/generate"
 )
 
 var writerPool = sync.Pool{
 	New: func() any {
-		return &oj.Writer{Options: oj.DefaultOptions}
+		opts := oj.DefaultOptions
+		opts.TimeFormat = time.RFC3339
+		return &oj.Writer{Options: opts}
 	},
 }
 

--- a/pkg/template/json/helper_test.go
+++ b/pkg/template/json/helper_test.go
@@ -20,11 +20,12 @@ import (
 	"math"
 	"runtime"
 	"testing"
+	"time"
 
 	// third-party libraries.
 	. "github.com/smartystreets/goconvey/convey"
 
-	// this project.
+	// first-party libraries.
 	"github.com/vanus-labs/vanus/lib/bytes"
 )
 
@@ -107,6 +108,12 @@ func TestHelper(t *testing.T) {
 		Convey("append string", func() {
 			str := appendInJSONString(nil, "\"foo\"\n")
 			So(string(str), ShouldEqual, `\"foo\"\n`)
+		})
+
+		Convey("append time", func() {
+			tt := time.Now()
+			str := appendInJSONString(nil, tt)
+			So(string(str), ShouldEqual, tt.Format(time.RFC3339))
 		})
 	})
 
@@ -268,6 +275,13 @@ func TestHelper(t *testing.T) {
 			runtime.ReadMemStats(&stats1)
 			So(stats1.Mallocs-stats0.Mallocs, ShouldEqual, 0)
 			So(stats1.HeapAlloc-stats0.HeapAlloc, ShouldEqual, 0)
+		})
+
+		Convey("write time", func() {
+			tt := time.Now()
+			err := writeInJSONString(&buf, tt)
+			So(err, ShouldBeNil)
+			So(buf.String(), ShouldEqual, tt.Format(time.RFC3339))
 		})
 	})
 }

--- a/pkg/template/json/template_test.go
+++ b/pkg/template/json/template_test.go
@@ -17,6 +17,7 @@ package json
 import (
 	// standard libraries.
 	"testing"
+	"time"
 
 	// third-party libraries.
 	. "github.com/smartystreets/goconvey/convey"
@@ -134,6 +135,15 @@ func newTestExecFunc(tp template.Template, model any, variables map[string]any, 
 			v, err := tp.Execute(model, variables)
 			So(err, ShouldBeNil)
 			So(string(v), ShouldEqual, `{"key":"<a\r\nb>","key2":"<b\r\na>"}`)
+		})
+
+		Convey("time value", func() {
+			tt, _ := time.Parse(time.RFC3339, "2018-04-05T17:31:00Z")
+			m["var"] = tt
+			m["var2"] = tt
+			v, err := tp.Execute(model, variables)
+			So(err, ShouldBeNil)
+			So(string(v), ShouldEqual, `{"key":"2018-04-05T17:31:00Z","key2":"\"2018-04-05T17:31:00Z\""}`)
 		})
 	}
 }

--- a/pkg/template/json/template_test.go
+++ b/pkg/template/json/template_test.go
@@ -143,7 +143,7 @@ func newTestExecFunc(tp template.Template, model any, variables map[string]any, 
 			m["var2"] = tt
 			v, err := tp.Execute(model, variables)
 			So(err, ShouldBeNil)
-			So(string(v), ShouldEqual, `{"key":"2018-04-05T17:31:00Z","key2":"\"2018-04-05T17:31:00Z\""}`)
+			So(string(v), ShouldEqual, `{"key":"2018-04-05T17:31:00Z","key2":"2018-04-05T17:31:00Z"}`)
 		})
 	}
 }

--- a/pkg/template/text/helper.go
+++ b/pkg/template/text/helper.go
@@ -29,9 +29,7 @@ import (
 
 var writerPool = sync.Pool{
 	New: func() any {
-		opts := oj.DefaultOptions
-		opts.TimeFormat = time.RFC3339
-		return &oj.Writer{Options: opts}
+		return &oj.Writer{Options: oj.DefaultOptions}
 	},
 }
 
@@ -47,6 +45,8 @@ func write(w io.Writer, v any) error {
 		return writeJSON(w, v)
 	case string:
 		return ignoreCount(w.Write(bytes.UnsafeFromString(val)))
+	case time.Time:
+		return ignoreCount(w.Write(bytes.UnsafeFromString(val.Format(time.RFC3339))))
 	default:
 		return writeJSON(w, v)
 	}

--- a/pkg/template/text/helper.go
+++ b/pkg/template/text/helper.go
@@ -18,16 +18,20 @@ import (
 	// standard libraries.
 	"io"
 	"sync"
+	"time"
 
 	// third-party libraries.
 	"github.com/ohler55/ojg/oj"
 
+	// first-party libraries.
 	"github.com/vanus-labs/vanus/lib/bytes"
 )
 
 var writerPool = sync.Pool{
 	New: func() any {
-		return &oj.Writer{Options: oj.DefaultOptions}
+		opts := oj.DefaultOptions
+		opts.TimeFormat = time.RFC3339
+		return &oj.Writer{Options: opts}
 	},
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to Vanus!

PR Title Format: 

feat/fix/refactor/docs/...: what's changed

Note: see https://github.com/vanus-labs/vanus/blob/main/CONTRIBUTING.md to know details about title format

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem

There MUST be one line starting with "Issue Number:  ".

-->

template does not follow the RFC3339 time format.

### Problem Summary

### What is changed and how does it work?

### Check List

<!-- At least one of them must be included. -->

#### Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
