### PR TITLE
fix: json template render bad empty array and empty object

### DIFF
--- a/pkg/template/json/generator.go
+++ b/pkg/template/json/generator.go
@@ -79,13 +79,13 @@ func (g *templateGenerator) generate(root templateNode) []templateSegment {
 }
 
 func (g *templateGenerator) generateObjectNode(node *objectNode, i int) bool {
+	if i == 0 {
+		g.buf.WriteByte('{')
+	}
+
 	if i >= len(node.members) {
 		g.buf.WriteByte('}')
 		return false
-	}
-
-	if i == 0 {
-		g.buf.WriteByte('{')
 	}
 
 	mn := node.members[i]
@@ -114,13 +114,13 @@ func (g *templateGenerator) generateObjectNode(node *objectNode, i int) bool {
 }
 
 func (g *templateGenerator) generateArrayNode(node *arrayNode, i int) bool {
+	if i == 0 {
+		g.buf.WriteByte('[')
+	}
+
 	if i >= len(node.elements) {
 		g.buf.WriteByte(']')
 		return false
-	}
-
-	if i == 0 {
-		g.buf.WriteByte('[')
 	}
 
 	en := node.elements[i]

--- a/pkg/template/json/template_test.go
+++ b/pkg/template/json/template_test.go
@@ -27,6 +27,18 @@ import (
 )
 
 func TestTemplate_Execute(t *testing.T) {
+	Convey("empty array and empty object", t, func() {
+		model := map[string]interface{}{}
+		variables := map[string]interface{}{}
+
+		tp, err := Compile(`[{"empty array":[],"empty object":{}}]`)
+		So(err, ShouldBeNil)
+
+		v, err := tp.Execute(model, variables)
+		So(err, ShouldBeNil)
+		So(string(v), ShouldEqual, `[{"empty array":[],"empty object":{}}]`)
+	})
+
 	Convey("refer variables", t, func() {
 		model := map[string]interface{}{}
 		variables := map[string]interface{}{}


### PR DESCRIPTION
### What problem does this PR solve?

JSON template renders bad empty array and empty object

### Problem Summary

- missing '[' when renders empty array
- missing '{' when renders empty object

### What has changed and how does it work?

### Check List

<!-- At least one of them must be included. -->

#### Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
